### PR TITLE
Fix unbind null and improve error handling

### DIFF
--- a/src/SoundCloud.js
+++ b/src/SoundCloud.js
@@ -66,7 +66,7 @@ class SoundCloud extends React.Component {
    * @param {Object} Widget
    */
 
-  _setupWidget(widget) {
+  _setupWidget = (widget) => {
     this._internalWidget = widget;
     this._bindEvents();
   }
@@ -80,7 +80,7 @@ class SoundCloud extends React.Component {
    * time the url changes it breaks the back button. Super bummer.
    */
 
-  _reloadWidget() {
+  _reloadWidget = () => {
     this._internalWidget.load(this.props.url, this.props.opts);
   }
 

--- a/src/lib/createWidget.js
+++ b/src/lib/createWidget.js
@@ -12,10 +12,19 @@ import load from 'load-script';
  */
 
 const createWidget = (id, cb) => {
+  if (window.SC) {
+    // the API was alread loaded, return widget asynchronously
+    setTimeout(() => cb(window.SC.Widget(id)), 0);
+  } else {
     // load the API, it's namespaced as `window.SC`
-  return load('https://w.soundcloud.com/player/api.js', () => {
-    return cb(window.SC.Widget(id)); // eslint-disable-line new-cap
-  });
+    load('https://w.soundcloud.com/player/api.js', (err) => {
+      if (err) throw new Error(`Failed to load Soundcloud API: ${err.message}`)
+
+      if (!window.SC) throw new Error(`Soundcloud namespace is not available after API loaded`)
+
+      return cb(window.SC.Widget(id)); // eslint-disable-line new-cap
+    });
+  }
 };
 
 /**


### PR DESCRIPTION
This PR aims to fix several errors I encountered.

The _reloadWidget and _setupWidget were called in the callback function of createWidget, meaning their __this__ is not pointing to the instance of the react class. This was solved with autobinding using arrow functions.

I noticed other errors occurring where window.SC was not defined somehow, so I've added error handling. 
